### PR TITLE
Revert "okular: qca not support openssl@1.1 (conflicts with kf5-khtml…

### DIFF
--- a/okular.rb
+++ b/okular.rb
@@ -14,7 +14,7 @@ class Okular < Formula
   depends_on "KDE-mac/kde/kf5-khtml" => :build
 
   depends_on "qt"
-  #depends_on "qca"
+  depends_on "qca"
   depends_on "zlib"
   depends_on "freetype"
   depends_on "libspectre"


### PR DESCRIPTION
…)" (fixed)

This reverts commit 20861fab0f4ef1a1b8dc67b49ddad6f61c986886.