### PR TITLE
Fix installation of dolphin

### DIFF
--- a/dolphin.rb
+++ b/dolphin.rb
@@ -18,6 +18,7 @@ class Dolphin < Formula
   depends_on "KDE-mac/kde/kf5-kcmutils"
   depends_on "KDE-mac/kde/kf5-kparts"
   depends_on "KDE-mac/kde/kf5-kinit"
+  depends_on "KDE-mac/kde/kf5-kdelibs4support"
   depends_on "KDE-mac/kde/kio-extras"
 
   def install

--- a/kf5-kdelibs4support.rb
+++ b/kf5-kdelibs4support.rb
@@ -12,7 +12,7 @@ class Kf5Kdelibs4support < Formula
   depends_on "KDE-mac/kde/kf5-kdoctools" => :build
 
   depends_on "qt"
-  depends_on "openssl@1.1"
+  depends_on "openssl"
   depends_on "docbook"
   depends_on "KDE-mac/kde/kf5-kded"
   depends_on "KDE-mac/kde/kf5-kemoticons"


### PR DESCRIPTION
Dolphin previously failed to install for me because the kdelibs4support dependency was missing.
After I added that dependency I got a dependency conflict between `openssl` and `openssl@1.1` due to the kio-extras dependency. I've now updated kdelibs4support to use `openssl` instead which fixes the issue for me. With these changes I was able to launch dolphin and browse files.