### PR TITLE
Add missing breeze-icons dependency to dolphin

### DIFF
--- a/dolphin.rb
+++ b/dolphin.rb
@@ -14,6 +14,7 @@ class Dolphin < Formula
   depends_on :ruby => ["2.4", :optional]
   depends_on "KDE-mac/kde/konsole" => [:run, :optional]
 
+  depends_on "KDE-mac/kde/kf5-breeze-icons"
   depends_on "KDE-mac/kde/kf5-kcmutils"
   depends_on "KDE-mac/kde/kf5-kdelibs4support"
   depends_on "KDE-mac/kde/kf5-kfilemetadata"


### PR DESCRIPTION
Without this I don't get any icons when running dolphin