### PR TITLE
Rename kf5-breeze.icons with kf5-breeze-icons

### DIFF
--- a/kate.rb
+++ b/kate.rb
@@ -14,7 +14,7 @@ class Kate < Formula
 
   depends_on "KDE-mac/kde/konsole" => [:run, :optional]
 
-  depends_on "KDE-mac/kde/kf5-breeze.icons"
+  depends_on "KDE-mac/kde/kf5-breeze-icons"
   depends_on "KDE-mac/kde/kf5-kactivities"
   depends_on "KDE-mac/kde/kf5-kitemmodels"
   depends_on "KDE-mac/kde/kf5-knewstuff"

--- a/kmymoney.rb
+++ b/kmymoney.rb
@@ -19,7 +19,7 @@ class Kmymoney < Formula
   depends_on "boost"
   depends_on "libical"
   depends_on "libofx"
-  depends_on "KDE-mac/kde/kf5-breeze.icons"
+  depends_on "KDE-mac/kde/kf5-breeze-icons"
   depends_on "KDE-mac/kde/kf5-kcmutils"
   depends_on "KDE-mac/kde/kf5-kio"
   depends_on "KDE-mac/kde/libalkimia"

--- a/konsole.rb
+++ b/konsole.rb
@@ -11,7 +11,7 @@ class Konsole < Formula
   depends_on "KDE-mac/kde/kf5-extra-cmake-modules" => :build
   depends_on "kde-mac/kde/kf5-kdoctools" => :build
 
-  depends_on "KDE-mac/kde/kf5-breeze.icons"
+  depends_on "KDE-mac/kde/kf5-breeze-icons"
   depends_on "KDE-mac/kde/kf5-kinit"
   depends_on "KDE-mac/kde/kf5-knotifyconfig"
   depends_on "KDE-mac/kde/kf5-kparts"

--- a/konversation.rb
+++ b/konversation.rb
@@ -12,7 +12,7 @@ class Konversation < Formula
   depends_on "KDE-mac/kde/kf5-kdoctools" => :build
 
   depends_on "qca"
-  depends_on "KDE-mac/kde/kf5-breeze.icons"
+  depends_on "KDE-mac/kde/kf5-breeze-icons"
   depends_on "KDE-mac/kde/kf5-kemoticons"
   depends_on "KDE-mac/kde/kf5-kidletime"
   depends_on "KDE-mac/kde/kf5-knotifyconfig"

--- a/okteta.rb
+++ b/okteta.rb
@@ -12,7 +12,7 @@ class Okteta < Formula
   depends_on "KDE-mac/kde/kf5-kdoctools" => :build
 
   depends_on "qca"
-  depends_on "KDE-mac/kde/kf5-breeze.icons"
+  depends_on "KDE-mac/kde/kf5-breeze-icons"
   depends_on "KDE-mac/kde/kf5-kcmutils"
   depends_on "KDE-mac/kde/kf5-knewstuff"
   depends_on "KDE-mac/kde/kf5-kparts"

--- a/okular.rb
+++ b/okular.rb
@@ -22,7 +22,7 @@ class Okular < Formula
   depends_on "libspectre"
   depends_on "djvulibre"
   depends_on "poppler" => "with-qt"
-  depends_on "KDE-mac/kde/kf5-breeze.icons"
+  depends_on "KDE-mac/kde/kf5-breeze-icons"
   depends_on "KDE-mac/kde/kf5-kactivities"
   depends_on "KDE-mac/kde/kf5-kjs"
   depends_on "KDE-mac/kde/kf5-kparts"


### PR DESCRIPTION
In some formulas, `kf5-breeze-icons` dependencies might be misspelled?