### PR TITLE
Fix okular build issue

### DIFF
--- a/okular.rb
+++ b/okular.rb
@@ -36,6 +36,13 @@ class Okular < Formula
   end
   patch :DATA
 
+  stable do
+    patch do
+      url "https://phabricator.kde.org/file/data/2wvots3vggm53vjkm72r/PHID-FILE-ttv6g4vnc65feqzauhm4/file"
+      sha256 "702b39e7d2d2c471dea9fa55a46420f26c286df929823cab374fc25264a76d58"
+    end
+  end
+
   def install
     args = std_cmake_args
     args << "-DBUILD_TESTING=OFF"


### PR DESCRIPTION
When I tried to install okular, build process stopped at cmake.

```
% brew install kde-mac/kde/okular
==> Installing okular from kde-mac/kde
==> Downloading https://download.kde.org/stable/applications/17.08.3/src/okular-17.08.3.tar.xz
Already downloaded: /Users/nakaoyuji/Library/Caches/Homebrew/okular-17.08.3.tar.xz
==> Downloading https://raw.githubusercontent.com/RJVB/macstrop/master/kf5/kf5-okular/files/patch-plugin-depend
Already downloaded: /Users/nakaoyuji/Library/Caches/Homebrew/okular--patch-33e5e0fa2a10fea2f11a1b975bfee3d87d80215aedb8013ea2d318818a250a46.diff
==> Patching
==> Applying patch-plugin-depends.diff
patching file mobile/components/CMakeLists.txt
Hunk #1 succeeded at 30 (offset 1 line).
patching file CMakeLists.txt
Hunk #1 succeeded at 204 (offset 14 lines).
patching file core/utils.cpp
==> cmake .. -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -DCMAKE_INSTALL_PREFIX=/usr/lo
Last 15 lines from /Users/nakaoyuji/Library/Logs/Homebrew/okular/01.cmake:

    MODULE

  Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
  .hxx .in .txx


-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    HAVE_CLOCK_GETTIME


-- Build files have been written to: /tmp/okular-20171129-44746-g5dje0/okular-17.08.3/build

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
https://github.com/KDE-mac/homebrew-kde/issues

brew install kde-mac/kde/okular  44.03s user 12.16s system 82% cpu 1:08.48 total
```

Full logs are [here](https://gist.github.com/ynakao/fed80ec2f4af3f7d7858848a06a77778). It seems an error occured in `generators/spectre/CMakeLists.txt` according to `01.cmake` file.

```
CMake Error in generators/spectre/CMakeLists.txt:
  Cannot find source file:

    MODULE

  Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
  .hxx .in .txx
```

There is [an upstream commit](https://phabricator.kde.org/D8612) to resolve this issue, but it isn't included in the current `okular-17.08.3.tar.xz` tarball.

So, [this patch](https://gist.github.com/ynakao/0e0248609ce2d53bb6c9613af3bba25e) is needed to build (except when installing with `--HEAD` option) **until KDE apps updates**. After next stable okular arrives, this patch should be removed, I think.

Environment:
OS X 10.11.6
Xcode 8.2.1
cmake 3.10.0
