### PR TITLE
Fix kf5-sonnet.rb patch conflict

### DIFF
--- a/kf5-sonnet.rb
+++ b/kf5-sonnet.rb
@@ -35,7 +35,7 @@ class Kf5Sonnet < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     You need to take some manual steps in order to make this formula work:
       ln -sf "$(brew --prefix)/share/kf5" "$HOME/Library/Application Support"
      EOS

--- a/kf5-sonnet.rb
+++ b/kf5-sonnet.rb
@@ -49,11 +49,9 @@ index f8c99d1..f2fa4a9 100644
 --- a/src/plugins/nsspellchecker/CMakeLists.txt
 +++ b/src/plugins/nsspellchecker/CMakeLists.txt
 @@ -7,6 +7,8 @@ add_library(sonnet_nsspellchecker MODULE ${sonnet_nsspellchecker_PART_SRCS})
- 
+
  target_link_libraries(sonnet_nsspellchecker PRIVATE KF5::SonnetCore "-framework Cocoa")
- 
+
 +target_compile_definitions(sonnet_nsspellchecker PRIVATE "QT_NO_EXCEPTIONS")
 +
- set_target_properties(sonnet_nsspellchecker PROPERTIES OUTPUT_NAME "nsspellchecker")
  install(TARGETS sonnet_nsspellchecker  DESTINATION ${KDE_INSTALL_PLUGINDIR}/kf5/sonnet/)
- 


### PR DESCRIPTION
Fixes the patching issue and compiles sonnet successfully. Essentially it removes the following line from the patch:

```
set_target_properties(sonnet_nsspellchecker PROPERTIES OUTPUT_NAME "nsspellchecker")
```