### PR TITLE
Add Kirigami2 dependency to fix build failure

### DIFF
--- a/Formula/kf5-plasma-framework.rb
+++ b/Formula/kf5-plasma-framework.rb
@@ -15,6 +15,7 @@ class Kf5PlasmaFramework < Formula
 
   depends_on "KDE-mac/kde/kf5-kactivities"
   depends_on "KDE-mac/kde/kf5-kdeclarative"
+  depends_on "KDE-mac/kde/kf5-kirigami2"
 
   patch :DATA
 


### PR DESCRIPTION
kf5-plasma-frameworks fails build in newer version due to missing dependency. Adding the above fixes it.