### PR TITLE
Changes to fix building with 5.45.0 frameworks and some extras

### DIFF
--- a/Formula/kf5-kdelibs4support.rb
+++ b/Formula/kf5-kdelibs4support.rb
@@ -12,7 +12,7 @@ class Kf5Kdelibs4support < Formula
   depends_on "KDE-mac/kde/kf5-kdesignerplugin" => :build
   depends_on "KDE-mac/kde/kf5-kdoctools" => :build
 
-  depends_on "openssl@1.1"
+  depends_on "openssl"
   depends_on "KDE-mac/kde/kf5-kded"
   depends_on "KDE-mac/kde/kf5-kemoticons"
   depends_on "KDE-mac/kde/kf5-kitemmodels"

--- a/Formula/kf5-khtml.rb
+++ b/Formula/kf5-khtml.rb
@@ -10,7 +10,7 @@ class Kf5Khtml < Formula
   depends_on "gperf" => :build
   depends_on "KDE-mac/kde/kf5-extra-cmake-modules" => :build
 
-  depends_on "openssl@1.1"
+  depends_on "openssl"
   depends_on "jpeg"
   depends_on "giflib"
   depends_on "libpng"

--- a/Formula/kf5-kio.rb
+++ b/Formula/kf5-kio.rb
@@ -6,6 +6,9 @@ class Kf5Kio < Formula
 
   head "git://anongit.kde.org/kio.git"
 
+  # Fix getxattr which takes six inputs in macOS
+  patch :DATA
+
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "graphviz" => :build
@@ -44,3 +47,38 @@ class Kf5Kio < Formula
     EOS
   end
 end
+
+__END__
+diff --git a/src/ioslaves/file/file_unix.cpp b/src/ioslaves/file/file_unix.cpp
+index 9c9a83b..4eafbc8 100644
+--- a/src/ioslaves/file/file_unix.cpp
++++ b/src/ioslaves/file/file_unix.cpp
+@@ -418,13 +418,13 @@ static bool isNtfsHidden(const QString &filename)
+ {
+     constexpr auto attrName = "system.ntfs_attrib_be";
+     const auto filenameEncoded = QFile::encodeName(filename);
+-    auto length = getxattr(filenameEncoded.data(), attrName, nullptr, 0);
++    auto length = getxattr(filenameEncoded.data(), attrName, nullptr, 0, 0, XATTR_NOFOLLOW);
+     if (length <= 0) {
+         return false;
+     }
+     constexpr size_t xattr_size = 1024;
+     char strAttr[xattr_size];
+-    length = getxattr(filenameEncoded.data(), attrName, strAttr, xattr_size);
++    length = getxattr(filenameEncoded.data(), attrName, strAttr, xattr_size, 0, XATTR_NOFOLLOW);
+     if (length <= 0) {
+         return false;
+     }
+diff --git a/src/widgets/kpropertiesdialog.cpp b/src/widgets/kpropertiesdialog.cpp
+index 17e1688..f2b8a37 100644
+--- a/src/widgets/kpropertiesdialog.cpp
++++ b/src/widgets/kpropertiesdialog.cpp
+@@ -1943,7 +1943,7 @@ static bool fileSystemSupportsACL(const QByteArray &path)
+     fileSystemSupportsACLs = (statfs(path.data(), &buf) == 0) && (buf.f_flags & MNT_ACLS);
+ #else
+     fileSystemSupportsACLs =
+-        getxattr(path.data(), "system.posix_acl_access", nullptr, 0) >= 0 || errno == ENODATA;
++        getxattr(path.data(), "system.posix_acl_access", nullptr, 0, 0, XATTR_NOFOLLOW) >= 0 || errno == ENODATA;
+ #endif
+     return fileSystemSupportsACLs;
+ }

--- a/Formula/kf5-plasma-framework.rb
+++ b/Formula/kf5-plasma-framework.rb
@@ -17,6 +17,7 @@ class Kf5PlasmaFramework < Formula
   depends_on "KDE-mac/kde/kf5-kdeclarative"
   depends_on "KDE-mac/kde/kf5-kirigami2"
 
+  # Mark executables as nongui type
   patch :DATA
 
   def install
@@ -44,28 +45,28 @@ class Kf5PlasmaFramework < Formula
   end
 end
 
-# Mark executables as nongui type
 __END__
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index b628ff7f1..bb2014d7b 100644
+index fb7b76b..71ee8a4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -24,6 +24,7 @@ include(ECMQtDeclareLoggingCategory)
- include(ECMAddQch)
+@@ -25,6 +25,7 @@ include(ECMAddQch)
  include(KDEPackageAppTemplates)
  include(ECMGenerateQmlTypes)
+ include(ECMSetupQtPluginMacroNames)
 +include(ECMMarkNonGuiExecutable)
- 
+
  option(BUILD_QCH "Build API documentation in QCH format (for e.g. Qt Assistant, Qt Creator & KDevelop)" OFF)
  add_feature_info(QCH ${BUILD_QCH} "API documentation in QCH format (for e.g. Qt Assistant, Qt Creator & KDevelop)")
 diff --git a/src/plasmapkg/CMakeLists.txt b/src/plasmapkg/CMakeLists.txt
-index 6247f9249..20186d788 100644
+index 6247f92..20186d7 100644
 --- a/src/plasmapkg/CMakeLists.txt
 +++ b/src/plasmapkg/CMakeLists.txt
 @@ -2,5 +2,6 @@ add_executable(plasmapkg2 main.cpp)
- 
+
  target_link_libraries(plasmapkg2 Qt5::Core)
- 
+
 +ecm_mark_nongui_executable(plasmapkg2)
  install(TARGETS plasmapkg2 ${KF5_INSTALL_TARGETS_DEFAULT_ARGS})
- 
+
+

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -2,9 +2,12 @@
 
 [[ -f "/tmp/kf5_dep_map" ]] && rm /tmp/kf5_dep_map
 
-for formula in `ls kf5-*.rb`; do
+formuladir=$(brew --prefix)/Homebrew/Library/Taps/kde-mac/homebrew-kde/Formula
+
+for formula in $formuladir/kf5-*.rb; do
+  formulaname=`basename $formula`
   for dep in `grep "depends_on" $formula | awk -F "\"" '{print $2}'`; do
-    echo "${dep/kde-mac\/kde\//} ${formula//\.rb/}" >> /tmp/kf5_dep_map
+    echo "${dep/[k,K][d,D][e,E]-mac\/kde\//} ${formulaname//\.rb/}" >> /tmp/kf5_dep_map
   done
 done
 


### PR DESCRIPTION
I found that a few of the formula would not install while depending on openssl@1.1 because in their dependency tree they depended on python@2 which depends on openssl and then brew would complain. While changing the dependency to openssl the updated formula do compile and install, I haven't tested them yet as I'm still working out how to do that.

install.sh was broken because it wasn't matching the capital case in the formula "depends_on" line which reads KDE-mac/kde/kf5-*.rb and thus resulted in formula being listed twice and perhaps not in the correct order. I did not use case modification in bash parameter expansion since my native version of bash is v3.2 (I am using OS X 10.11.6) and bash v3.2 doesn't have case modification. After fixing install.sh it now lists each formula only once, but there is a complaint from tsort:
```
tsort: cycle in data
tsort: kf5-plasma-framework
tsort: kf5-kirigami2
tsort: cycle in data
tsort: kio-extras
tsort: kf5-kio
```
and strangely `kf5-tier1-frameworks` is listed after `kf5-tier2-frameworks` in the install order so perhaps `kf5-tier1-frameworks` is missing some dependencies.

Also I had to patch `kf5-kio.rb` to get it to build because getxattr has two extra parameters on mac. The first extra parameter should be 0, but the last one can be XATTR_NOFOLLOW or XATTR_SHOWCOMPRESSON. I was not sure which behavior is really desired and I don't know if my change is correct or if it will lead to problems, but kf5-kio does build; however, I don't know how to test it yet.