### PR TITLE
Some fixes for various packages

### DIFF
--- a/Formula/kf5-kfilemetadata.rb
+++ b/Formula/kf5-kfilemetadata.rb
@@ -14,7 +14,7 @@ class Kf5Kfilemetadata < Formula
   depends_on "exiv2"
   depends_on "ffmpeg"
   depends_on "taglib"
-  depends_on "poppler"
+  depends_on "poppler" => "with-qt"
   depends_on "KDE-mac/kde/kf5-karchive"
   depends_on "KDE-mac/kde/kf5-ki18n"
 

--- a/Formula/kf5-ki18n.rb
+++ b/Formula/kf5-ki18n.rb
@@ -3,6 +3,7 @@ class Kf5Ki18n < Formula
   homepage "https://www.kde.org"
   url "https://download.kde.org/stable/frameworks/5.45/ki18n-5.45.0.tar.xz"
   sha256 "b70e62cd355b02c6160b69b210fd7f4bd44fb341e013db8dc81c744332e55cf6"
+  version "5.45.0-1" # Remove version number and patch when upgrading to 5.46.0
 
   head "git://anongit.kde.org/ki18n.git"
 

--- a/Formula/kf5-ki18n.rb
+++ b/Formula/kf5-ki18n.rb
@@ -14,6 +14,14 @@ class Kf5Ki18n < Formula
 
   depends_on "qt"
 
+  # This patch is already in upstream and should be removed for the next
+  # stable version, but without this patch we cannot build any KDE
+  # applications that depend on this package because while building it will
+  # hit the maximum number of proecesses per user limit and crash the system
+  stable do
+    patch :DATA
+  end
+
   def install
     args = std_cmake_args
     args << "-DBUILD_TESTING=OFF"
@@ -30,3 +38,16 @@ class Kf5Ki18n < Formula
     end
   end
 end
+
+__END__
+diff --git a/cmake/build-pofiles.cmake b/cmake/build-pofiles.cmake
+index d0991ad..b39be31 100644
+--- a/cmake/build-pofiles.cmake
++++ b/cmake/build-pofiles.cmake
+@@ -62,6 +62,7 @@ foreach(pofile IN LISTS pofiles)
+     if(i EQUAL ${numberOfProcesses})
+         _processCommands()
+         set(i 0)
++        set(commands)
+     endif()
+ endforeach()

--- a/Formula/kf5-tier1-frameworks.rb
+++ b/Formula/kf5-tier1-frameworks.rb
@@ -3,7 +3,7 @@ class Kf5Tier1Frameworks < Formula
   homepage "https://api.kde.org/frameworks"
   system "touch", "/tmp/empty"
   url "file:///tmp/empty"
-  version "0"
+  version "5.45.0"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   depends_on "KDE-mac/kde/kf5-attica" => :build

--- a/Formula/kf5-tier1-frameworks.rb
+++ b/Formula/kf5-tier1-frameworks.rb
@@ -1,7 +1,8 @@
 class Kf5Tier1Frameworks < Formula
   desc "Metapackage for Tier 1 KF5 frameworks"
   homepage "https://api.kde.org/frameworks"
-  url "https://raw.githubusercontent.com/KDE-mac/homebrew-kde/master/tools/empty"
+  system "touch", "/tmp/empty"
+  url "file:///tmp/empty"
   version "0"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 

--- a/Formula/kf5-tier2-frameworks.rb
+++ b/Formula/kf5-tier2-frameworks.rb
@@ -3,7 +3,7 @@ class Kf5Tier2Frameworks < Formula
   homepage "https://api.kde.org/frameworks"
   system "touch", "/tmp/empty"
   url "file:///tmp/empty"
-  version "0"
+  version "5.45.0"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   depends_on "KDE-mac/kde/kf5-tier1-frameworks" => :build

--- a/Formula/kf5-tier2-frameworks.rb
+++ b/Formula/kf5-tier2-frameworks.rb
@@ -1,10 +1,12 @@
 class Kf5Tier2Frameworks < Formula
   desc "Metapackage for Tier 2 KF5 frameworks"
   homepage "https://api.kde.org/frameworks"
-  url "https://raw.githubusercontent.com/KDE-mac/homebrew-kde/master/tools/empty"
+  system "touch", "/tmp/empty"
+  url "file:///tmp/empty"
   version "0"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
+  depends_on "KDE-mac/kde/kf5-tier1-frameworks" => :build
   depends_on "KDE-mac/kde/kf5-kactivities" => :build
   depends_on "KDE-mac/kde/kf5-kauth" => :build
   depends_on "KDE-mac/kde/kf5-kcompletion" => :build

--- a/Formula/kf5-tier3-frameworks.rb
+++ b/Formula/kf5-tier3-frameworks.rb
@@ -1,10 +1,12 @@
 class Kf5Tier3Frameworks < Formula
   desc "Metapackage for Tier 3 KF5 frameworks"
   homepage "https://api.kde.org/frameworks"
-  url "https://raw.githubusercontent.com/KDE-mac/homebrew-kde/master/tools/empty"
+  system "touch", "/tmp/empty"
+  url "file:///tmp/empty"
   version "0"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
+  depends_on "KDE-mac/kde/kf5-tier2-frameworks" => :build
   depends_on "KDE-mac/kde/kf5-kbookmarks" => :build
   depends_on "KDE-mac/kde/kf5-kcmutils" => :build
   depends_on "KDE-mac/kde/kf5-kconfigwidgets" => :build

--- a/Formula/kf5-tier3-frameworks.rb
+++ b/Formula/kf5-tier3-frameworks.rb
@@ -3,7 +3,7 @@ class Kf5Tier3Frameworks < Formula
   homepage "https://api.kde.org/frameworks"
   system "touch", "/tmp/empty"
   url "file:///tmp/empty"
-  version "0"
+  version "5.45.0"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   depends_on "KDE-mac/kde/kf5-tier2-frameworks" => :build

--- a/Formula/kf5-tier4-frameworks.rb
+++ b/Formula/kf5-tier4-frameworks.rb
@@ -1,0 +1,16 @@
+class Kf5Tier4Frameworks < Formula
+  desc "Metapackage for Tier 4 KF5 frameworks"
+  homepage "https://api.kde.org/frameworks"
+  system "touch", "/tmp/empty"
+  url "file:///tmp/empty"
+  version "0"
+  sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+  depends_on "KDE-mac/kde/kf5-tier3-frameworks" => :build
+  depends_on "KDE-mac/kde/kf5-frameworkintegration" => :build
+
+  def install
+    touch "empty"
+    prefix.install "empty"
+  end
+end

--- a/Formula/kf5-tier4-frameworks.rb
+++ b/Formula/kf5-tier4-frameworks.rb
@@ -3,7 +3,7 @@ class Kf5Tier4Frameworks < Formula
   homepage "https://api.kde.org/frameworks"
   system "touch", "/tmp/empty"
   url "file:///tmp/empty"
-  version "0"
+  version "5.45.0"
   sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
   depends_on "KDE-mac/kde/kf5-tier3-frameworks" => :build

--- a/Formula/kmymoney.rb
+++ b/Formula/kmymoney.rb
@@ -2,7 +2,7 @@ class Kmymoney < Formula
   desc "Personal finance manager similar to MS-Money or Quicken"
   homepage "https://kmymoney.org"
   url "http://download.kde.org/stable/kmymoney/5.0.1/src/kmymoney-5.0.1.tar.xz"
-  sha256 "c20118890fcd140799e44c8d923956d914e9c8ab"
+  sha256 "dd6e8fc22a48ddcb322565c8f385d6aa44d582cfcf6fe2ff3dc11fc0b6bd2ab1"
 
   head "git://anongit.kde.org/kmymoney.git"
 

--- a/Formula/libalkimia.rb
+++ b/Formula/libalkimia.rb
@@ -2,7 +2,7 @@ class Libalkimia < Formula
   desc "Library used by KDE Finance applications"
   homepage "https://kmymoney.org"
   url "http://download.kde.org/stable/alkimia/7.0.2/alkimia-7.0.2.tar.xz"
-  sha256 "32493ff4277a48fd9e754242afe017942ef8458e"
+  sha256 "59e6b10d819479bc8dde53a8b10e6ec05e9d465c5e035528a5c0b036456a2454"
   head "git://anongit.kde.org/alkimia.git"
 
   depends_on "cmake" => :build

--- a/Formula/okular.rb
+++ b/Formula/okular.rb
@@ -20,7 +20,7 @@ class Okular < Formula
   depends_on "freetype"
   depends_on "libspectre"
   depends_on "djvulibre"
-  depends_on "poppler"
+  depends_on "poppler" => "with-qt"
   depends_on "KDE-mac/kde/kf5-breeze-icons"
   depends_on "KDE-mac/kde/kf5-kactivities"
   depends_on "KDE-mac/kde/kf5-kjs"

--- a/tools/update-formulas-tiers.sh
+++ b/tools/update-formulas-tiers.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+VERSION=5.45.0
+
+for FORMULA in $(brew --repo kde-mac/kde)/Formula/kf5-tier*; do
+
+  PREVIOUS_VERSION=$(sed -n 's/.*version "\(.*\)"/\1/p' $FORMULA)
+
+  if [ $VERSION != $PREVIOUS_VERSION ]; then
+    echo Updating version $PREVIOUS_VERSION to $VERSION in $(basename $FORMULA)
+    sed -i "s/$PREVIOUS_VERSION/$VERSION/g" $FORMULA
+  else
+    echo No change to version in $(basename $FORMULA)
+  fi
+
+done


### PR DESCRIPTION
The crucial fix here is for `kf5-ki18n` which is necessary for building most of the kde applications. This package has a bug which has already been fixed upstream, but we need to patch the stable version. This bug was causing a huge number of processes to be spawned which resulted in crashing macOS due to hitting the maxproc limit. When the limit was hit clang fails executing posix_spawn which send it and all parent processes into an uninterruptible sleep (stuck processes in darwin). The only fix was a hard reboot.