### PR TITLE
Update kf5-ki18n for 5.46.0

### DIFF
--- a/Formula/kf5-ki18n.rb
+++ b/Formula/kf5-ki18n.rb
@@ -3,7 +3,7 @@ class Kf5Ki18n < Formula
   homepage "https://www.kde.org"
   url "https://download.kde.org/stable/frameworks/5.46/ki18n-5.46.0.tar.xz"
   sha256 "da8eb3ddc002ad88c3bec817aa2f38fbe73894d2c019544195bc43ec66af9253"
-  version "5.45.0"
+  version "5.46.0"
 
   head "git://anongit.kde.org/ki18n.git"
 
@@ -14,14 +14,6 @@ class Kf5Ki18n < Formula
   depends_on "KDE-mac/kde/kf5-extra-cmake-modules" => :build
 
   depends_on "qt"
-
-  # This patch is already in upstream and should be removed for the next
-  # stable version, but without this patch we cannot build any KDE
-  # applications that depend on this package because while building it will
-  # hit the maximum number of proecesses per user limit and crash the system
-  stable do
-    patch :DATA
-  end
 
   def install
     args = std_cmake_args
@@ -39,16 +31,3 @@ class Kf5Ki18n < Formula
     end
   end
 end
-
-__END__
-diff --git a/cmake/build-pofiles.cmake b/cmake/build-pofiles.cmake
-index d0991ad..b39be31 100644
---- a/cmake/build-pofiles.cmake
-+++ b/cmake/build-pofiles.cmake
-@@ -62,6 +62,7 @@ foreach(pofile IN LISTS pofiles)
-     if(i EQUAL ${numberOfProcesses})
-         _processCommands()
-         set(i 0)
-+        set(commands)
-     endif()
- endforeach()


### PR DESCRIPTION
The version number was set incorrectly for this formula. 
Also as noted in the comments I have removed the patch since its been landed upstream.