### PR TITLE
Add Analitza v18.04.3

### DIFF
--- a/Formula/analitza.rb
+++ b/Formula/analitza.rb
@@ -1,0 +1,27 @@
+class Analitza < Formula
+  desc "A library to add mathematical features to your program"
+  homepage "https://edu.kde.org/"
+  url "https://download.kde.org/stable/applications/18.04.3/src/analitza-18.04.3.tar.xz"
+  sha256 "aef8f3f46ed35294b857d26419cc0affc568e97990448cccfd4f71c492046afb"
+
+  head "git://anongit.kde.org/analitza.git"
+
+  depends_on "cmake" => :build
+  depends_on "KDE-mac/kde/kf5-extra-cmake-modules" => :build
+  depends_on "KDE-mac/kde/kf5-kdoctools" => :build
+  depends_on "eigen" => :build
+      
+  def install
+    args = std_cmake_args
+    args << "-DCMAKE_INSTALL_PREFIX=#{prefix}"
+    args << "-DCMAKE_INSTALL_LIBDIR=#{lib}"
+    args << "-DBUILD_TESTING=OFF"
+    args << "-DCMAKE_PREFIX_PATH=" + Formula["qt"].opt_prefix + "/lib/cmake"
+      
+    mkdir "build" do
+      system "cmake", "..", *args
+      system "make", "install"
+      prefix.install "install_manifest.txt"
+    end
+  end
+end

--- a/Formula/analitza.rb
+++ b/Formula/analitza.rb
@@ -8,8 +8,8 @@ class Analitza < Formula
 
   depends_on "cmake" => :build
   depends_on "eigen" => :build
-  depends_on "KDE-mac/kde/kf5-extra-cmake-modules" => :build
-  depends_on "KDE-mac/kde/kf5-kdoctools" => :build
+  depends_on "kf5-extra-cmake-modules" => :build
+  depends_on "kf5-kdoctools" => :build
 
   def install
     args = std_cmake_args

--- a/Formula/analitza.rb
+++ b/Formula/analitza.rb
@@ -1,5 +1,5 @@
 class Analitza < Formula
-  desc "A library to add mathematical features to your program"
+  desc "Library to add mathematical features to your program"
   homepage "https://edu.kde.org/"
   url "https://download.kde.org/stable/applications/18.04.3/src/analitza-18.04.3.tar.xz"
   sha256 "aef8f3f46ed35294b857d26419cc0affc568e97990448cccfd4f71c492046afb"
@@ -7,21 +7,25 @@ class Analitza < Formula
   head "git://anongit.kde.org/analitza.git"
 
   depends_on "cmake" => :build
+  depends_on "eigen" => :build
   depends_on "KDE-mac/kde/kf5-extra-cmake-modules" => :build
   depends_on "KDE-mac/kde/kf5-kdoctools" => :build
-  depends_on "eigen" => :build
-      
+
   def install
     args = std_cmake_args
     args << "-DCMAKE_INSTALL_PREFIX=#{prefix}"
     args << "-DCMAKE_INSTALL_LIBDIR=#{lib}"
     args << "-DBUILD_TESTING=OFF"
     args << "-DCMAKE_PREFIX_PATH=" + Formula["qt"].opt_prefix + "/lib/cmake"
-      
+
     mkdir "build" do
       system "cmake", "..", *args
       system "make", "install"
       prefix.install "install_manifest.txt"
     end
+  end
+
+  test do
+    system "false"
   end
 end


### PR DESCRIPTION
Dependence for `cantor`. I will upload that formula and also that of `labplot`.

In `cantor` ([formula](https://github.com/fjperini/homebrew-kde/blob/cantor/Formula/cantor.rb)) there is an inconvenience, you can see it [here](https://gist.github.com/fjperini/798eda66ef37713c680017dcd8a59c2b) to suggest a solution.

```
[ 17%] Built target cantorlibs
make: *** [all] Error 2
```
For `labplot` I needed to do:

```
brew unlink gettext && brew link --force gettext
```

I noticed that only the English language is available in the KDE apps. To enable others?

<img width="1440" alt="kde" src="https://user-images.githubusercontent.com/21315242/42735348-a187f320-8828-11e8-85f8-b53864154460.png">


Everything else works correctly!

