### PR TITLE
do-caveats.sh: new tools script

### DIFF
--- a/tools/do-caveats.sh
+++ b/tools/do-caveats.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+export IFS=" "
+
+for formulapath in `brew --repo kde-mac/kde`/Formula/*; do
+  if [[ `grep -c "caveats" "$formulapath"` -ge 1 ]]
+  then
+    formula=`basename $formulapath`
+    formulaname=${formula/.rb/}
+    formulainfo=`brew info $formulaname`
+    if [[ `echo $formulainfo | grep -c "Built from source"` -ge 1 ]]
+	then
+      mkdir -pv $HOME/Applications/KDE
+      echo "Linking $formulaname"
+      eval `echo $formulainfo | grep "ln -s" | awk '{$1=$1; print $0}'`
+    fi
+  fi
+done


### PR DESCRIPTION
Does the caveats of all formula which are currently installed. This
script is somewhat slow because it calls brew every for every formula to
see if it is installed. If its necessary to make this faster brew can be
called once with all the formula name, but it would be more difficult to
see which formula are installed and what their caveats are.

Addresses Issue #171